### PR TITLE
Clarify parameter documentation for options object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Set permissions on the extracted files, i.e `{mode: '755'}`.
 
 Type: `number`
 
-Removes, or flattens, a number of leading directories from each file in the archive.
+Removes (or flattens) a number of leading directories from each file in the archive.
 
 Equivalent to `--strip-components` for tar.
 

--- a/readme.md
+++ b/readme.md
@@ -26,15 +26,19 @@ gulp.task('default', function () {
 
 ## Options
 
+Type: `object`
+
 ### mode
 
 Type: `string`
 
-Set mode on the extracted files, i.e `{mode: '755'}`.
+Set permissions on the extracted files, i.e `{mode: '755'}`.
 
 ### strip
 
 Type: `number`
+
+Removes, or flattens, a number of leading directories from each file in the archive.
 
 Equivalent to `--strip-components` for tar.
 


### PR DESCRIPTION
--strip-components was something I never used, so I clarified it in the README.md to help save other people the google search and tinkering to figure out what it does. Also, "mode" was a little ambiguous, so I use the word "permissions" in its description.