### PR TITLE
Ensure directories always have null contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = opts => new Transform({
 
 					this.push(new gutil.File({
 						stat,
-						contents: x.data,
+						contents: stat.isDirectory() ? null : x.data,
 						path: x.path
 					}));
 				});


### PR DESCRIPTION
For a vinyl File to report itself as a directory (via ```isDirectory()```) it must not only have a stat that reports that it is a directory but it must also have ```null``` as the contents. In some circumstances, ```decompress``` can yield a non-```null``` data for some directories. When this happens, the corresponding chunks in the output pipeline report as files not as directories, which causes problems down the line. To avoid this, ignore any data field for directories and ensure that the ```contents``` are explicitly set to ```null```.