### PR TITLE
fix output param

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = opts => new Transform({
 			return;
 		}
 
-		decompress(file.contents, opts)
+		decompress(file.contents, opts.output, opts)
 			.then(files => {
 				for (const x of files) {
 					const stat = new fs.Stats();

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = opts => new Transform({
 			return;
 		}
 
-		decompress(file.contents, opts.output, opts)
+		decompress(file.contents, opts && opts.output, opts)
 			.then(files => {
 				for (const x of files) {
 					const stat = new fs.Stats();


### PR DESCRIPTION
Decompress expects 'output' as a param and not in the opts object.

Receive it in opts and use it as param.

